### PR TITLE
Dates & Times on the When tab can not be saved when using Firefox Quantum

### DIFF
--- a/includes/js/rendez-vous-backbone.js
+++ b/includes/js/rendez-vous-backbone.js
@@ -433,7 +433,7 @@ var rdv = rdv || {};
 			'blur .rdv-input-what' : 'storeWhatInput',
 			'click .rdv-check-what' : 'storeWhatInput',
 			'change .rdv-select-what' : 'storeWhatInput',
-			'blur .rdv-input-when' : 'storeWhenInput',
+			'change .rdv-input-when' : 'storeWhenInput',
 			'click .trashday' : 'trashDay',
 		},
 


### PR DESCRIPTION
This .js file may then need to be minified into rendez-vous-backbone.min.js. Since I'm using Autoptimize, I skipped the minification process in my projects and just rendez-vous.php to load rendez-vous-backbone.js instead.